### PR TITLE
Fix --lang parameter cannot use all to select all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ string-catalog translate /path_or_dir/to/xcstrings_file --model anthropic/claude
 --lang zh-Hant
 ```
 
+Translate a single xcstrings file and all supported languages using deepseek-v3 API
+
+```bash
+string-catalog translate /path_or_dir/to/xcstrings_file --base-url https://api.deepseek.com --api-key sk-xxxx --model deepseek-chat --lang all
+```
+
 - All API call results are cached in the `.translation_cache/` directory and will be used first for subsequent calls.
 
 The translation results have a default state of `needs_review`. If you need to update them to `translated` (for example, after reviewing all translations in Xcode and wanting to avoid manually clicking "Mark as Reviewed" for each one), you can use the following command:

--- a/string_catalog/cli.py
+++ b/string_catalog/cli.py
@@ -11,6 +11,10 @@ from .language import Language
 from .models import StringCatalog, TranslationState
 from .utils import find_catalog_files, save_catalog, update_string_unit_state
 
+AVAILABLE_LANGUAGES = "".join(
+    f"| {lang.value}: {lang.name.replace('_', ' ').title()}"
+    for lang in Language
+)
 
 app = typer.Typer(
     add_completion=False,
@@ -39,7 +43,7 @@ def translate(
         ...,
         "--lang",
         "-l",
-        help="Target language(s) or 'all' for all common languages",
+        help=f"Target language(s) or 'all' for all common languages. Available languages: {AVAILABLE_LANGUAGES}",
     ),
     overwrite: bool = typer.Option(
         False, "--overwrite", help="Overwrite existing translations"

--- a/string_catalog/cli.py
+++ b/string_catalog/cli.py
@@ -35,7 +35,7 @@ def translate(
         "--model",
         "-m",
     ),
-    languages: List[Language] = typer.Option(
+    languages: List[str] = typer.Option(
         ...,
         "--lang",
         "-l",
@@ -52,7 +52,11 @@ def translate(
         if len(languages) == 1 and languages[0].lower() == "all":
             target_langs = set(Language.all_common())
         else:
-            target_langs = {Language(lang) for lang in languages}
+            try:
+                target_langs = {Language(lang) for lang in languages}
+            except ValueError as e:
+                print(f"[red]Error: Invalid language code. {str(e)}[/red]")
+                raise typer.Exit(1)
     else:
         target_langs = None
 


### PR DESCRIPTION
1. Fix --lang parameter cannot use all to select all languages
2. Update the README.md file by adding an example of using the deepseek-v3 API to translate a single xcstrings file.